### PR TITLE
wordle.py: fix word scoring

### DIFF
--- a/wordle/python/wordle.py
+++ b/wordle/python/wordle.py
@@ -69,17 +69,34 @@ def get_play(bot, history):
 def calc_score(secret, guess, wordlist):
     if not guess in wordlist:
         return '0' * len(secret)
-    a = []
-    for i, ch in enumerate(secret):
+
+    a = ['0'] * len(secret)
+    secret_arr = [char for char in secret]
+
+    # First pass of the guess, to find any that match exactly
+    for i, ch in enumerate(secret_arr):
         g = '-'
         if i < len(guess):
             g = guess[i]
-        if g == ch:
-            a.append('3')
-        elif g in secret:
-            a.append('2')
+        if ch == g:
+            a[i] = '3'
+            secret_arr[i] = ' '
+
+    # Second pass to score the rest, without re-using the secret letters more than once
+    for i, ch in enumerate(secret_arr):
+        if a[i] == '3':
+            continue
+        g = '-'
+        if i < len(guess):
+            g = guess[i]
+
+        if g in secret_arr:
+            idx = secret_arr.index(g)
+            secret_arr[idx] = ' '
+            a[i] = '2'
         else:
-            a.append('1')
+            a[i] = '1'
+
     return ''.join(a)
 
 


### PR DESCRIPTION
Previously the word scoring did not match the scoring in the online wordle game. This change fixes the calc_score method.

In the online version, each character in the secret can only be used once to 'light up' a tile. If there are repeated letters in the guess, letters in the guess are matched first if they are in the same position.

More concretely, here are some examples of the previous / new behavior:

| secret | guess | previous scoring method | new scoring method|
|---|---|---|---|
| ylems | neeld | 12321 | 11321 |
| abbey | abaca | 33212 | 33111 |
| banal | union | 12112 | 12111 |
| banal | alloy | 22211 | 22111 |
| banal | annal | 22333 | 22333 |

There is a [Reddit post](https://www.reddit.com/r/wordle/comments/ry49ne/illustration_of_what_happens_when_your_guess_has/) with more details.